### PR TITLE
Fix build workflow container reference

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ jobs:
   cmake:
     runs-on: msvc-wine
     container:
+      image: ghcr.io/mstorsjo/msvc-wine:latest
       volumes:
         - /var/run/pcscd/pcscd.comm:/var/run/pcscd/pcscd.comm
     steps:


### PR DESCRIPTION
## Summary
- specify the container image for the build job

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687ec6828c40832aad9294f56a3c19fe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build workflow to specify a container image for the build environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->